### PR TITLE
Add some needed dependencies explicitly

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "Gruntfile.js",
     "package.json"
   ],
-  "repository": {                                              
+  "repository": {
     "type": "git",
     "url": "git://github.com/paf31/purescript-string-parsers.git"
   },
@@ -25,7 +25,9 @@
     "purescript-arrays": "~0.4.2",
     "purescript-maybe": "~0.3.4",
     "purescript-strings": "~0.7.0",
-    "purescript-foldable-traversable": "~0.4.0"
+    "purescript-foldable-traversable": "~0.4.0",
+    "purescript-either": "~0.2.3",
+    "purescript-lists": "~0.7.8"
   },
   "devDependencies": {
     "purescript-math": "~0.2.0",


### PR DESCRIPTION
So this package builds on its own, but if you were to have a package that has
this one as its only dependency, it fails to build because it's missing the
packages this commit includes.