### PR TITLE
No regex

### DIFF
--- a/src/Text/Parsing/StringParser/String.purs
+++ b/src/Text/Parsing/StringParser/String.purs
@@ -29,8 +29,6 @@ import Control.Alt ((<|>))
 import Text.Parsing.StringParser.Combinators (many, (<?>))
 import Text.Parsing.StringParser
 
-import qualified Data.String.Regex as Rx
-
 -- | Match the end of the file.
 eof :: Parser Unit
 eof = Parser (\s fc sc -> case s of
@@ -46,16 +44,11 @@ anyChar = Parser (\s fc sc -> case s of
 
 -- | Match any digit.
 anyDigit :: Parser Char
-anyDigit = Parser \{ str: str, pos: i } fc sc -> case charAt i str of
-  Just chr ->
-    let chrS = fromChar chr
-    in if Rx.test rxDigit chrS
-       then sc chr { str: str, pos: i + 1 }
-       else fc i (ParseError "Expected digit")
-  Nothing -> fc i (ParseError "Unexpected EOF")
-  where
-  rxDigit :: Rx.Regex
-  rxDigit = Rx.regex "^[0-9]" Rx.noFlags
+anyDigit = try do
+  c <- anyChar
+  if c >= '0' && c <= '9'
+     then return c
+     else fail $ "Character " <> toString c <> " is not a digit"
 
 -- | Match the specified string.
 string :: String -> Parser String

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -72,3 +72,5 @@ main = do
   parseTest opTest "a+b+c"
   parseTest exprTest "1*2+3/4-5"
   parseTest tryTest "aacc"
+  parseTest (many1 anyDigit) "0/" 
+  parseTest (many1 anyDigit) "9:" 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -72,5 +72,5 @@ main = do
   parseTest opTest "a+b+c"
   parseTest exprTest "1*2+3/4-5"
   parseTest tryTest "aacc"
-  parseTest (many1 anyDigit) "0/" 
-  parseTest (many1 anyDigit) "9:" 
+  parseTest (many1 anyDigit) "01234/" 
+  parseTest (many1 anyDigit) "56789:" 


### PR DESCRIPTION
Remove usage of Regex for parsing digits, it's unnecessary and it seems V8 doesn't cache them (see attached). Perhaps Purescript compiler should support outputting the regex literal, since they are part of EcmaScript?

![screenshot from 2016-01-26 13 08 55](https://cloud.githubusercontent.com/assets/125019/12580250/3e37c298-c42e-11e5-9b60-c29ac65e3b64.png)
